### PR TITLE
отложенная отправка email.

### DIFF
--- a/BackgroudServices/ScheduledTasks/Maintance/MailSenderBackgroundService.cs
+++ b/BackgroudServices/ScheduledTasks/Maintance/MailSenderBackgroundService.cs
@@ -1,0 +1,63 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using BackgroudServices.Scheduling;
+using CloudArchive.Services;
+using DATABASE.Context;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CloudArchive.ScheduledTasks
+{
+    public class MailSenderBackgroundService: IScheduledTask
+    {
+        public string ServiceName { get => "MailSenderBackgroundService"; }
+        private readonly IServiceScopeFactory _serviceScopeFactory;
+
+        public MailSenderBackgroundService(IServiceScopeFactory serviceScopeFactory)
+        {
+            _serviceScopeFactory = serviceScopeFactory;
+        }
+
+        public async Task ExecuteAsync(CancellationToken cancellationToken)
+        {
+            await Task.Yield();
+            try
+            {
+                using (var scope = _serviceScopeFactory.CreateScope())
+                {
+                    IBackgroundServiceLog backgroundServiceLog = scope.ServiceProvider.GetRequiredService<IBackgroundServiceLog>();
+                    SearchServiceDBContext dbContext = scope.ServiceProvider.GetRequiredService<SearchServiceDBContext>();
+                    IEmailService emailService = scope.ServiceProvider.GetRequiredService<IEmailService>();
+                    var emailQueue = dbContext.EmailQueue.Where(eq => !eq.Sent.HasValue);
+                    foreach (var email in emailQueue)
+                    {
+                        var result = await emailService.SendEmailAsync(
+                            email.Recipients.Split(',').ToList(), 
+                            email.Subject, 
+                            email.Body, 
+                            email.EmailQueueDocFiles.Select(ed => ed.DocFile).ToList());
+                        if (result == "OK")
+                        {
+                            email.Sent = DateTime.Now;
+                        }
+                        else
+                        {
+                            backgroundServiceLog.AddError(result, ServiceName);
+                        }
+                    }
+
+                    await dbContext.SaveChangesAsync();
+                }
+            }
+            catch (Exception)
+            {
+            }
+            await Task.Delay(JobScheduler.GetWaitDelay(ServiceName), cancellationToken);
+        }
+    }
+}

--- a/BackgroudServices/Scheduling/JobScheduler.cs
+++ b/BackgroudServices/Scheduling/JobScheduler.cs
@@ -25,6 +25,7 @@ namespace BackgroudServices.Scheduling
                 _Schedules.Add("FTPBackgroundService", "0 */2 * * *");
                 _Schedules.Add("IMAPBackgroundService", "0/5 * * * *");
                 _Schedules.Add("MaintanceBackgroundService", "0 0/1 * * *");
+                _Schedules.Add("MailSenderBackgroundService", "* * * * *");
                 _Schedules.Add("ClientNotificationService", "0 3 1/1 * *");
                 _Schedules.Add("WFUserNotificationService", "30 1 * * 1-5");
                 _Schedules.Add("RemoveBlockedClientsService", "0 4 1/1 * *");

--- a/BackgroudServices/Startup.cs
+++ b/BackgroudServices/Startup.cs
@@ -87,6 +87,7 @@ namespace BackgroudServices
 
       
             services.AddSingleton<IScheduledTask, MaintanceBackgroundService>();
+            services.AddSingleton<IScheduledTask, MailSenderBackgroundService>();
 
             //services.AddSingleton<IScheduledTask, MigrationService>();
 

--- a/COMMON/Workflow/Workflow.cs
+++ b/COMMON/Workflow/Workflow.cs
@@ -184,7 +184,7 @@ namespace COMMON.Workflow
             bool ret = false;
             try
             {
-                MailConstructor mailer = new MailConstructor(_commonService, _emailSender, _cfg, _currentTheme);
+                MailConstructor mailer = new MailConstructor(_commonService, _dbContext, _cfg, _currentTheme);
                 mailer.SetTemplate(MailTemplate.Approval_Task);
                 string tasktype = modelArr.Count > 0 ? modelArr[0].TaskType : "";
                 var ttype = TaskTypes.Where(x => x.TaskTypeName == tasktype).FirstOrDefault();
@@ -502,7 +502,7 @@ namespace COMMON.Workflow
                 string tasktype = _nextTasks.Any() ? _nextTasks.FirstOrDefault().TaskType : "";
                 Doclink = "<a href='" + _cfg["HttpClient_Address"] + "/newstyle/document/view?ItemId=" + DocID + "&SettName=" + Settname + "'>" + DocName + "</a>";
                 ttype = TaskTypes.Where(x => x.TaskTypeNumber == model.TaskType).FirstOrDefault();
-                MailConstructor mailer = new MailConstructor(_commonService, _emailSender, _cfg, _currentTheme);
+                MailConstructor mailer = new MailConstructor(_commonService, _dbContext, _cfg, _currentTheme);
 
                 if (!model.Agreed)
                     mailer.SetTemplate(MailTemplate.Approval_Decline);
@@ -825,7 +825,7 @@ namespace COMMON.Workflow
                         newtask.Order = task.Order;
                         task.Order = task.Order - 1;
                     }
-                    MailConstructor mailer = new MailConstructor(_commonService, _emailSender, _cfg, _currentTheme);
+                    MailConstructor mailer = new MailConstructor(_commonService, _dbContext, _cfg, _currentTheme);
 
                     var nexttype = TaskTypes.Where(x => x.TaskTypeName == newtask.TaskType).FirstOrDefault();
                     if (nexttype.TaskTypeNumber == 1)

--- a/DATABASE/Context/SearchServiceDBContext.cs
+++ b/DATABASE/Context/SearchServiceDBContext.cs
@@ -50,6 +50,7 @@ namespace DATABASE.Context
         public DbSet<AdditionalField> AdditionalFields { get; set; }
         public DbSet<ContractExtended> ContractsExtended { get; set; }
         public DbSet<MetadataExtended> MetadatasExtended { get; set; }
+        public DbSet<EmailQueue> EmailQueue { get; set; }
 
         public SearchServiceDBContext(DbContextOptions<SearchServiceDBContext> options) : base(options)
         {
@@ -75,6 +76,8 @@ namespace DATABASE.Context
 
             builder.Entity<ContractExtended>().ToView("ContractsExtended").HasKey(t => t.Id);
             builder.Entity<MetadataExtended>().ToView("MetadatasExtended").HasKey(t => t.Id);
+            builder.Entity<EmailQueue>().HasIndex(eq => eq.Sent);
+            builder.Entity<EmailQueueDocFile>().HasKey(ed => new {ed.EmailQueueId, ed.DocFileId});
 
             foreach (var relationship in builder.Model.GetEntityTypes().SelectMany(e => e.GetForeignKeys()))
             {

--- a/DATABASE/Entities/EmailQueue.cs
+++ b/DATABASE/Entities/EmailQueue.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace ARCHIVE.COMMON.Entities
+{
+    public class EmailQueue
+    {
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public long Id { get; set; }
+        public DateTime Created { get; set; }
+        public DateTime? Sent { get; set; }
+        [Required]
+        public string Recipients { get; set; }
+        public string Subject { get; set; }
+        public string Body { get; set; }
+        public List<EmailQueueDocFile> EmailQueueDocFiles { get; set; }
+    }
+}

--- a/DATABASE/Entities/EmailQueueDocFile.cs
+++ b/DATABASE/Entities/EmailQueueDocFile.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace ARCHIVE.COMMON.Entities
+{
+    public class EmailQueueDocFile
+    {
+        // в новых версиях EFCore (5+) промежуточная модель не нужна
+        public long EmailQueueId { get; set; }
+        public EmailQueue EmailQueue { get; set; }
+        public long DocFileId { get; set; }
+        public DocFile DocFile { get; set; }
+    }
+}

--- a/DATABASE/Migrations/20221103162646_AddTableEmailQueue.Designer.cs
+++ b/DATABASE/Migrations/20221103162646_AddTableEmailQueue.Designer.cs
@@ -3,14 +3,16 @@ using System;
 using DATABASE.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace DATABASE.Migrations
 {
     [DbContext(typeof(SearchServiceDBContext))]
-    partial class SearchServiceDBContextModelSnapshot : ModelSnapshot
+    [Migration("20221103162646_AddTableEmailQueue")]
+    partial class AddTableEmailQueue
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DATABASE/Migrations/20221103162646_AddTableEmailQueue.cs
+++ b/DATABASE/Migrations/20221103162646_AddTableEmailQueue.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace DATABASE.Migrations
+{
+    public partial class AddTableEmailQueue : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "EmailQueue",
+                columns: table => new
+                {
+                    Id = table.Column<long>(nullable: false)
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                    Created = table.Column<DateTime>(nullable: false),
+                    Sent = table.Column<DateTime>(nullable: true),
+                    Recipients = table.Column<string>(nullable: false),
+                    Subject = table.Column<string>(nullable: true),
+                    Body = table.Column<string>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_EmailQueue", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "EmailQueueDocFile",
+                columns: table => new
+                {
+                    EmailQueueId = table.Column<long>(nullable: false),
+                    DocFileId = table.Column<long>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_EmailQueueDocFile", x => new { x.EmailQueueId, x.DocFileId });
+                    table.ForeignKey(
+                        name: "FK_EmailQueueDocFile_Files_DocFileId",
+                        column: x => x.DocFileId,
+                        principalTable: "Files",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_EmailQueueDocFile_EmailQueue_EmailQueueId",
+                        column: x => x.EmailQueueId,
+                        principalTable: "EmailQueue",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_EmailQueue_Sent",
+                table: "EmailQueue",
+                column: "Sent");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_EmailQueueDocFile_DocFileId",
+                table: "EmailQueueDocFile",
+                column: "DocFileId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "EmailQueueDocFile");
+
+            migrationBuilder.DropTable(
+                name: "EmailQueue");
+
+        }
+    }
+}


### PR DESCRIPTION
Работоспособность не проверялась

Не нашёл ограничений на длину списка получателей, и subject, потому использовал поле БД text. В реальной работе обратился бы за консультацией по размеру полей, скорее всего там достаточно varchar разумной длины.

Столкнулся с проблемой описаной тут https://github.com/dotnet/efcore/issues/28106. Не разбирался так как нет возможности проверить выполнение миграций, убрал изменения длины полей в таблицах AspNetUserTokens, AspNetUserLogins. 

Возвращаемое значение из EmailService игнорируется, обработку ошибок не добавлял, исключения игнорирую как и раньше.

Мне кажется достойным рассмотрения вариант с заменой EmailService на другую реализацию IEmailService, чтобы не пришлось вносить изменения в код и потенциально ломать код, использующий MailConstructor. По условию задания нужно было переделать только метод SendMail, но их несколько и нам нужно в них передавать DbContext. Безопасным решением было бы продублировать все методы добавив версию с DbContext и использовать её. В рамках тестового задания удаляю использование EmailService и добавляю в конструктор DbContext. Так же стоило бы переписать FillMetadataFields, чтобы DbContext инициализировался при создании MailConstructor и сам MailConstructor сделать сервисом в DI контейнере. В работе это потребует дополнительного обсуждения задачи.